### PR TITLE
Depend on the comment itself, instead of a submission built around the comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ El flow es bastante sencillo:
 * Monitorea los comentarios de un usuario en particular (u/empleadoEstatalBot en este caso)
 * Agarra los últimos n comentarios del usuario
 * Filtra de esos n comentarios para quedarse solo con los que sean dentro de los subreddits permitidos y que tenga mas de x palabras (no tiene sentido resumir una noticia de menos de 100 palabras, por ejemplo)
-* Por limitaciones de la API, no se puede acceder directamente a las respuestas del comentario. Así que se agarra el thread entero, y de ahí se agarra el primer comentario de todos, que es siempre el stickeado del empleado estatal.
 * Recorre todas las respuestas del comentario seleccionado. Si alguna es el mismo bot, entonces ya esta respondido. Si no, entonces queda por responder.
 * Con TextRank se responde el comentario original con un resumen de su texto
 * Se duerme el bot 1 minuto, y luego vuelve a empezar todo el loop.

--- a/resumidor_estatal.py
+++ b/resumidor_estatal.py
@@ -26,10 +26,11 @@ def summarize_news(parent_comment_body):
 
 def is_replied(comment):
     logging.debug("Trying to reply to: http://www.reddit.com" + comment.permalink)
-    stickied = reddit.submission(url='http://www.reddit.com'+comment.permalink).comments[0]
-    if not stickied.author == os.environ['REPLY_TO']: return True
-    if not stickied.replies.list(): return False
-    for sub_comment in stickied.replies.list():
+    comment.refresh()
+    comment.replies.replace_more()
+    if not comment.author == os.environ['REPLY_TO']: return True
+    if not comment.replies.list(): return False
+    for sub_comment in comment.replies.list():
         if sub_comment.author.name == os.environ['ME']:
             logging.debug("Skipping comment because it was already replied")
             return True


### PR DESCRIPTION
This also fixes the MoreComments object error, by calling the replace_more method

And also removes the dependency where the comment to reply __had__ to be the stickied/first one